### PR TITLE
Optional name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.12"
+sudo: false

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var dimensionsRegExp = /^(.*?)(-((\d+)?x?(\d+)?))?(@(\d+)x?)?$/i;
+var dimensionsRegExp = /(((\d+)?x?(\d+)?))?(@(\d+)x?)?$/i;
 
 module.exports = function (filename) {
   if (arguments.length < 1) {
@@ -10,12 +10,17 @@ module.exports = function (filename) {
     throw new Error('filename should be a string');
   }
 
+  var name;
+
   var match = filename.match(dimensionsRegExp);
 
-  var name = match[1];
-  var width = match[4] ? parseInt(match[4], 10) : null;
-  var height = match[5] ? parseInt(match[5], 10) : null;
-  var scale = match[7] ? parseInt(match[7], 10) : null;
+  var width = match[3] ? parseInt(match[3], 10) : null;
+  var height = match[4] ? parseInt(match[4], 10) : null;
+  var scale = match[6] ? parseInt(match[6], 10) : null;
+
+  name = filename.replace(match[0], '');
+  name = name.replace(/-$/, '');
+  name = name ? name : ( filename === '' ? '' : null );
 
   if (match) {
     return {

--- a/test/test.js
+++ b/test/test.js
@@ -90,4 +90,20 @@ describe('parse-image-dimensions', function () {
     expect(data).to.have.property('scale', 3);
   });
 
+  it('should parse with no name', function () {
+    var data = parse('500x600@3x');
+    expect(data).to.have.property('name', null);
+    expect(data).to.have.property('width', 500);
+    expect(data).to.have.property('height', 600);
+    expect(data).to.have.property('scale', 3);
+  });
+
+  it('should parse with no name and no scale', function () {
+    var data = parse('500x600');
+    expect(data).to.have.property('name', null);
+    expect(data).to.have.property('width', 500);
+    expect(data).to.have.property('height', 600);
+    expect(data).to.have.property('scale', null);
+  });
+
 });


### PR DESCRIPTION
This makes names optional so we can parse just the numbers, e.g. `320x480@2x`.

Added two new unit tests.

Need this for my [moonshot](https://github.com/adjohnson916/moonshot) project.
